### PR TITLE
Support SBT 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,6 @@ name := "cpd4sbt"
 version := "1.2.1-SNAPSHOT"
 
 sbtPlugin := true
-scalaVersion := "2.10.5"
+crossSbtVersions := Seq("0.13.16", "1.0.1")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:_")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,5 +1,5 @@
 bintrayOrganization := None
 bintrayRepository := "sbt-plugins"
-bintrayPackage <<= name
+bintrayPackage := { name.value }
 publishArtifact in Test := false
 publishMavenStyle := false

--- a/src/main/scala-sbt-0.13/de/johoop/cpd4sbt/Compat.scala
+++ b/src/main/scala-sbt-0.13/de/johoop/cpd4sbt/Compat.scala
@@ -1,0 +1,5 @@
+package de.johoop.cpd4sbt
+
+object Compat {
+  val Process = sbt.Process
+}

--- a/src/main/scala-sbt-1.0/de/johoop/cpd4sbt/Compat.scala
+++ b/src/main/scala-sbt-1.0/de/johoop/cpd4sbt/Compat.scala
@@ -1,0 +1,5 @@
+package de.johoop.cpd4sbt
+
+object Compat {
+  val Process = scala.sys.process.Process
+}

--- a/src/main/scala/de/johoop/cpd4sbt/CopyPasteDetector.scala
+++ b/src/main/scala/de/johoop/cpd4sbt/CopyPasteDetector.scala
@@ -14,16 +14,23 @@ package de.johoop.cpd4sbt
 import sbt._
 import Keys._
 
+import Compat.Process
+
 object CopyPasteDetector extends AutoPlugin {
 
   object autoImport extends CpdKeys
 
   import autoImport._
 
-  override lazy val projectConfigurations = Seq(Settings.cpdConfig)
+  override lazy val projectConfigurations = Seq(Settings.CpdConfig)
 
   override lazy val projectSettings = Settings.defaultSettings :+
-    (cpd <<= (cpdReportSettings, cpdSourceSettings, cpdMaxMemoryInMB, cpdClasspath, streams) map cpdAction)
+    (cpd := cpdAction(
+      cpdReportSettings.value,
+      cpdSourceSettings.value,
+      cpdMaxMemoryInMB.value,
+      cpdClasspath.value,
+      streams.value))
 
   private def cpdAction(reportSettings: ReportSettings, sourceSettings: SourceSettings, maxMem: Int, classpath: Classpath, streams: TaskStreams) {
     IO createDirectory reportSettings.path

--- a/src/main/scala/de/johoop/cpd4sbt/Settings.scala
+++ b/src/main/scala/de/johoop/cpd4sbt/Settings.scala
@@ -19,14 +19,14 @@ import ReportType._
 
 private[cpd4sbt] object Settings extends CpdKeys {
 
-  val cpdConfig = config("cpd") hide
+  val CpdConfig = config("cpd") hide
 
   val defaultSettings = Seq(
-    ivyConfigurations += cpdConfig,
+    ivyConfigurations += CpdConfig,
     libraryDependencies += "net.sourceforge.pmd" % "pmd-dist" % "5.4.2" % "cpd->default",
 
     cpdTargetPath := crossTarget.value / "cpd",
-    cpdSourceDirectories in Compile <<= unmanagedSourceDirectories in Compile,
+    cpdSourceDirectories in Compile := { (unmanagedSourceDirectories in Compile).value },
 
     cpdReportName := "cpd.xml",
     cpdMaxMemoryInMB := 512,
@@ -42,11 +42,27 @@ private[cpd4sbt] object Settings extends CpdKeys {
     cpdIgnoreIdentifiers := false,
     cpdIgnoreAnnotations := false,
 
-    cpdSourceSettings <<= cpdSourceSettings.dependsOn(compile in Compile),
+    cpdSourceSettings := { cpdSourceSettings.dependsOn(compile in Compile).value },
 
-    cpdReportSettings <<= (cpdTargetPath, cpdReportName, cpdReportFileEncoding, cpdReportType, cpdOutputType) map ReportSettings,
-    cpdSourceSettings <<= (cpdSourceDirectories in Compile, cpdSourceEncoding, cpdLanguage, cpdMinimumTokens, cpdSkipDuplicateFiles, cpdSkipLexicalErrors, cpdIgnoreLiterals, cpdIgnoreIdentifiers, cpdIgnoreAnnotations) map SourceSettings,
+    cpdReportSettings :=
+      ReportSettings(
+        cpdTargetPath.value,
+        cpdReportName.value,
+        cpdReportFileEncoding.value,
+        cpdReportType.value,
+        cpdOutputType.value),
+    cpdSourceSettings :=
+      SourceSettings(
+        (cpdSourceDirectories in Compile).value,
+        cpdSourceEncoding.value,
+        cpdLanguage.value,
+        cpdMinimumTokens.value,
+        cpdSkipDuplicateFiles.value,
+        cpdSkipLexicalErrors.value,
+        cpdIgnoreLiterals.value,
+        cpdIgnoreIdentifiers.value,
+        cpdIgnoreAnnotations.value),
 
-    cpdClasspath := Classpaths managedJars (cpdConfig, classpathTypes value, update value)
+    cpdClasspath := Classpaths managedJars (CpdConfig, classpathTypes value, update value)
   )
 }

--- a/test-project/project/build.properties
+++ b/test-project/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 1.0.1

--- a/test-project/project/cpd4sbt.sbt
+++ b/test-project/project/cpd4sbt.sbt
@@ -1,1 +1,1 @@
-lazy val root = Project("plugins", file(".")) dependsOn file("..").getAbsoluteFile.toURI
+lazy val root = Project("plugins", file(".")) dependsOn ProjectRef(file("..").getAbsoluteFile.toURI, "cpd4sbt")


### PR DESCRIPTION
This pull request adds support for cross building with SBT 0.13.16 and 1.0.1.
Running `^publish` should publish binaries for both versions of SBT.