### PR TITLE
use distinct directories in cpdSourceDirectories

### DIFF
--- a/src/main/scala/com/github/sbt/cpd/CpdPlugin.scala
+++ b/src/main/scala/com/github/sbt/cpd/CpdPlugin.scala
@@ -28,7 +28,7 @@ object CpdPlugin extends AutoPlugin {
   override lazy val projectSettings =
     Seq(
       cpdTargetPath := crossTarget.value / "cpd",
-      cpdSourceDirectories in Compile := { (unmanagedSourceDirectories in Compile).value },
+      cpdSourceDirectories in Compile := { (unmanagedSourceDirectories in Compile).value.distinct },
       cpdReportName := "cpd.xml",
       cpdMaxMemoryInMB := 512,
       cpdMinimumTokens := 100,


### PR DESCRIPTION
Fixes #13

use distinct directories in cpdSourceDirectories

#### Checklist

- [x] Unit tests pass.
- [x] Scripted tests pass.
- [x] I have run the above tests on sbt 0.13 _and_ 1.0.
- [x] You have read the contributing guide linked above.
