### PR TITLE
Bump pmd version to latest (6.35.0)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ scalacOptions ++= Seq(
   "-Ywarn-dead-code")
 
 libraryDependencies ++= Seq(
-  "net.sourceforge.pmd" %  "pmd-dist"   % "5.8.1",
+  "net.sourceforge.pmd" %  "pmd-core"   % "6.35.0",
+  "net.sourceforge.pmd" %  "pmd-java"   % "6.35.0",
   "org.scalatest"       %% "scalatest"  % "3.0.4"   % "test"
 )
 


### PR DESCRIPTION
removed redundant dependencies

Fixes #21 

I bumped the PMD version to the latest release and
removed dependendencies that (as far as I can see) are not needed by this plugin.


#### Checklist

- [x] Unit tests pass.
- [x] Scripted tests pass.
- [x] I have run the above tests on sbt 0.13 _and_ 1.0.
- [x] You have read the contributing guide linked above.
